### PR TITLE
Move theme toggle button to left sidebar

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,24 +11,6 @@
 </head>
 <body>
     <div class="container">
-        <!-- Theme Toggle Button -->
-        <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark/light mode">
-            <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="5"></circle>
-                <line x1="12" y1="1" x2="12" y2="3"></line>
-                <line x1="12" y1="21" x2="12" y2="23"></line>
-                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-                <line x1="1" y1="12" x2="3" y2="12"></line>
-                <line x1="21" y1="12" x2="23" y2="12"></line>
-                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-            </svg>
-            <svg class="theme-icon moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-            </svg>
-        </button>
-
         <header>
             <h1>Course Materials Assistant</h1>
             <p class="subtitle">Ask questions about courses, instructors, and content</p>
@@ -71,6 +53,26 @@
                             <button class="suggested-item" data-question="What was covered in lesson 5 of the MCP course?">Details of a course's lesson</button>
                         </div>
                     </details>
+                </div>
+
+                <!-- Theme Toggle Button -->
+                <div class="sidebar-section">
+                    <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark/light mode">
+                        <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="5"></circle>
+                            <line x1="12" y1="1" x2="12" y2="3"></line>
+                            <line x1="12" y1="21" x2="12" y2="23"></line>
+                            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                            <line x1="1" y1="12" x2="3" y2="12"></line>
+                            <line x1="21" y1="12" x2="23" y2="12"></line>
+                            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                        </svg>
+                        <svg class="theme-icon moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                        </svg>
+                    </button>
                 </div>
             </aside>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -783,37 +783,30 @@ details[open] .suggested-header::before {
 
 /* Theme Toggle Button */
 .theme-toggle {
-    position: fixed;
-    top: 1.5rem;
-    right: 1.5rem;
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    background: var(--surface);
+    width: 100%;
+    padding: 0.75rem;
+    border-radius: 8px;
+    background: var(--background);
     border: 1px solid var(--border-color);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: var(--shadow);
 }
 
 .theme-toggle:hover {
     background: var(--surface-hover);
     border-color: var(--primary-color);
-    transform: translateY(-2px);
-    box-shadow: 0 6px 12px -2px rgba(0, 0, 0, 0.3);
 }
 
 .theme-toggle:focus {
     outline: none;
-    box-shadow: 0 0 0 3px var(--focus-ring), var(--shadow);
+    box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .theme-toggle:active {
-    transform: translateY(0);
+    transform: scale(0.98);
 }
 
 /* Theme Icons */
@@ -847,9 +840,6 @@ body.light-mode .moon-icon {
 /* Responsive Theme Toggle */
 @media (max-width: 768px) {
     .theme-toggle {
-        top: 1rem;
-        right: 1rem;
-        width: 44px;
-        height: 44px;
+        padding: 0.5rem;
     }
 }


### PR DESCRIPTION
Moves the theme changer button from the top-right corner to the bottom of the left sidebar for better UI organization.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)